### PR TITLE
dlwrap: allow usage with -std=cXX

### DIFF
--- a/test/dlwrap.h
+++ b/test/dlwrap.h
@@ -56,7 +56,7 @@ dlwrap_real_dlsym(void *handle, const char *symbol);
 #define DEFER_TO_GL(library, func, name, args)                          \
 ({                                                                      \
     void *lib = dlwrap_real_dlopen(library, RTLD_LAZY | RTLD_LOCAL);    \
-    typeof(&func) real_func = dlwrap_real_dlsym(lib, name);             \
+    __typeof__(&func) real_func = dlwrap_real_dlsym(lib, name);             \
     /* gcc extension -- func's return value is the return value of      \
      * the statement.                                                   \
      */                                                                 \


### PR DESCRIPTION
typeof is not available. __typeof__ is as a GNU extension.